### PR TITLE
fix(print): converts to python3 syntax

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -22,9 +22,9 @@ def process(xcode, version):
       new_files = list(filter(lambda x : version in x, new_files))
 
   for i in new_files:
-    print 'Unzip file "{}.zip" to {}'.format(i, target)
+    print('Unzip file "{}.zip" to {}'.format(i, target))
     unzip_file(i, target)
-  print '\nUpdate successfully for {}'.format(xcode)
+  print('\nUpdate successfully for {}'.format(xcode))
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()


### PR DESCRIPTION
Since python 2.7 is being sunset: https://python3statement.org/,
Converting this script to run in python 3 syntax