### PR TITLE
deploy.py: add parentheses to print() call

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -22,9 +22,9 @@ def process(xcode, version):
       new_files = list(filter(lambda x : version in x, new_files))
 
   for i in new_files:
-    print 'Unzip file "{}.zip" to {}'.format(i, target)
+    print('Unzip file "{}.zip" to {}'.format(i, target))
     unzip_file(i, target)
-  print '\nUpdate successfully for {}'.format(xcode)
+  print('\nUpdate successfully for {}'.format(xcode))
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser()


### PR DESCRIPTION
to make the script work with Python 3